### PR TITLE
chore: write basic tests for termlink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
@@ -7,6 +9,11 @@ github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -15,3 +22,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/termlink_test.go
+++ b/termlink_test.go
@@ -1,0 +1,73 @@
+package termlink_test
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/savioxavier/termlink"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.Link("Hello", "https://google.com"), "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.Link("Hello", "https://google.com"), "Hello (\u200Bhttps://google.com)\u001b[m")
+	}
+}
+
+func TestColorLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red"),
+			"\x1b]8;;https://google.com\a\x1b[31mHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red"),
+			"\x1b[31mHello (\u200bhttps://google.com)\x1b[m")
+
+	}
+}
+
+func TestColorsPackageLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		// Check if color.Cyan(termlink.Link("Hello", "https://google.com")) will print the output to the terminal
+		assert.Equal(t, color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com")), "\x1b[36m\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m\x1b[0m")
+	} else {
+		assert.Equal(t, color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com")), "\x1b[36mHello (\u200bhttps://google.com)\x1b[m\x1b[0m")
+	}
+}
+
+func TestBoldLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold"),
+			"\x1b]8;;https://google.com\a\x1b[1mHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold"), "\x1b[1mHello (\u200bhttps://google.com)\x1b[m")
+	}
+}
+
+func TestItalicsLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "italic"),
+			"\x1b]8;;https://google.com\a\x1b[3mHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "italic"), "\x1b[3mHello (\u200bhttps://google.com)\x1b[m")
+	}
+}
+
+func TestItalicsBoldLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold italic"),
+			"\x1b]8;;https://google.com\a\x1b[1;3mHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold italic"), "\x1b[1;3mHello (\u200bhttps://google.com)\x1b[m")
+	}
+}
+
+func TestColorItalicsBoldLink(t *testing.T) {
+	if termlink.SupportsHyperlinks() {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red bold italic"),
+			"\x1b]8;;https://google.com\a\x1b[31;1;3mHello\x1b]8;;\a\x1b[m")
+	} else {
+		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red bold italic"), "\x1b[31;1;3mHello (\u200bhttps://google.com)\x1b[m")
+	}
+}

--- a/termlink_test.go
+++ b/termlink_test.go
@@ -8,86 +8,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBasicLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.Link("Hello", "https://google.com")
-		expected := "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.Link("Hello", "https://google.com")
-		expected := "Hello (\u200Bhttps://google.com)\u001b[m"
-		assert.Equal(t, input, expected)
+func testAll(input, expectedHyperlink, expectedNoHyperlink string) func(t *testing.T) {
+	return func(t *testing.T) {
+		if termlink.SupportsHyperlinks() {
+			assert.Equal(t, input, expectedHyperlink)
+		} else {
+			assert.Equal(t, input, expectedNoHyperlink)
+		}
 	}
+}
+
+func TestBasicLink(t *testing.T) {
+	input := termlink.Link("Hello", "https://google.com")
+	expectedHyperlink := "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "Hello (\u200Bhttps://google.com)\u001b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }
 
 func TestColorLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.ColorLink("Hello", "https://google.com", "red")
-		expected := "\x1b]8;;https://google.com\a\x1b[31mHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.ColorLink("Hello", "https://google.com", "red")
-		expected := "\x1b[31mHello (\u200bhttps://google.com)\x1b[m"
-		assert.Equal(t, input, expected)
-	}
+	input := termlink.ColorLink("Hello", "https://google.com", "red")
+	expectedHyperlink := "\x1b]8;;https://google.com\a\x1b[31mHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "\x1b[31mHello (\u200bhttps://google.com)\x1b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }
 
 func TestColorsPackageLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com"))
-		expected := "\x1b[36m\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m\x1b[0m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com"))
-		expected := "\x1b[36mHello (\u200bhttps://google.com)\x1b[m\x1b[0m"
-		assert.Equal(t, input, expected)
-	}
+	input := color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com"))
+	expectedHyperlink := "\x1b[36m\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m\x1b[0m"
+	expectedNoHyperlink := "\x1b[36mHello (\u200bhttps://google.com)\x1b[m\x1b[0m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }
 
 func TestBoldLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.ColorLink("Hello", "https://google.com", "bold")
-		expected := "\x1b]8;;https://google.com\a\x1b[1mHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.ColorLink("Hello", "https://google.com", "bold")
-		expected := "\x1b[1mHello (\u200bhttps://google.com)\x1b[m"
-		assert.Equal(t, input, expected)
-	}
+	input := termlink.ColorLink("Hello", "https://google.com", "bold")
+	expectedHyperlink := "\x1b]8;;https://google.com\a\x1b[1mHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "\x1b[1mHello (\u200bhttps://google.com)\x1b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }
 
 func TestItalicsLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.ColorLink("Hello", "https://google.com", "italic")
-		expected := "\x1b]8;;https://google.com\a\x1b[3mHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.ColorLink("Hello", "https://google.com", "italic")
-		expected := "\x1b[3mHello (\u200bhttps://google.com)\x1b[m"
-		assert.Equal(t, input, expected)
-	}
+	input := termlink.ColorLink("Hello", "https://google.com", "italic")
+	expectedHyperlink := "\x1b]8;;https://google.com\a\x1b[3mHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "\x1b[3mHello (\u200bhttps://google.com)\x1b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
+
 }
 
 func TestItalicsBoldLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.ColorLink("Hello", "https://google.com", "bold italic")
-		expected := "\x1b]8;;https://google.com\a\x1b[1;3mHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.ColorLink("Hello", "https://google.com", "bold italic")
-		expected := "\x1b[1;3mHello (\u200bhttps://google.com)\x1b[m"
-		assert.Equal(t, input, expected)
-	}
+	input := termlink.ColorLink("Hello", "https://google.com", "bold italic")
+	expectedHyperlink := "\x1b]8;;https://google.com\a\x1b[1;3mHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "\x1b[1;3mHello (\u200bhttps://google.com)\x1b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }
 
 func TestColorItalicsBoldLink(t *testing.T) {
-	if termlink.SupportsHyperlinks() {
-		input := termlink.ColorLink("Hello", "https://google.com", "red bold italic")
-		expected := "\x1b]8;;https://google.com\a\x1b[31;1;3mHello\x1b]8;;\a\x1b[m"
-		assert.Equal(t, input, expected)
-	} else {
-		input := termlink.ColorLink("Hello", "https://google.com", "red bold italic")
-		expected := "\x1b[31;1;3mHello (\u200bhttps://google.com)\x1b[m"
-		assert.Equal(t, input, expected)
-	}
+	input := termlink.ColorLink("Hello", "https://google.com", "red bold italic")
+	expectedHyperlink := "\x1b]8;;https://google.com\a\x1b[31;1;3mHello\x1b]8;;\a\x1b[m"
+	expectedNoHyperlink := "\x1b[31;1;3mHello (\u200bhttps://google.com)\x1b[m"
+
+	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
 }

--- a/termlink_test.go
+++ b/termlink_test.go
@@ -10,64 +10,84 @@ import (
 
 func TestBasicLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.Link("Hello", "https://google.com"), "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m")
+		input := termlink.Link("Hello", "https://google.com")
+		expected := "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.Link("Hello", "https://google.com"), "Hello (\u200Bhttps://google.com)\u001b[m")
+		input := termlink.Link("Hello", "https://google.com")
+		expected := "Hello (\u200Bhttps://google.com)\u001b[m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestColorLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red"),
-			"\x1b]8;;https://google.com\a\x1b[31mHello\x1b]8;;\a\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "red")
+		expected := "\x1b]8;;https://google.com\a\x1b[31mHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red"),
-			"\x1b[31mHello (\u200bhttps://google.com)\x1b[m")
-
+		input := termlink.ColorLink("Hello", "https://google.com", "red")
+		expected := "\x1b[31mHello (\u200bhttps://google.com)\x1b[m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestColorsPackageLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		// Check if color.Cyan(termlink.Link("Hello", "https://google.com")) will print the output to the terminal
-		assert.Equal(t, color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com")), "\x1b[36m\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m\x1b[0m")
+		input := color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com"))
+		expected := "\x1b[36m\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m\x1b[0m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com")), "\x1b[36mHello (\u200bhttps://google.com)\x1b[m\x1b[0m")
+		input := color.New(color.FgCyan).SprintFunc()(termlink.Link("Hello", "https://google.com"))
+		expected := "\x1b[36mHello (\u200bhttps://google.com)\x1b[m\x1b[0m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestBoldLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold"),
-			"\x1b]8;;https://google.com\a\x1b[1mHello\x1b]8;;\a\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "bold")
+		expected := "\x1b]8;;https://google.com\a\x1b[1mHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold"), "\x1b[1mHello (\u200bhttps://google.com)\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "bold")
+		expected := "\x1b[1mHello (\u200bhttps://google.com)\x1b[m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestItalicsLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "italic"),
-			"\x1b]8;;https://google.com\a\x1b[3mHello\x1b]8;;\a\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "italic")
+		expected := "\x1b]8;;https://google.com\a\x1b[3mHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "italic"), "\x1b[3mHello (\u200bhttps://google.com)\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "italic")
+		expected := "\x1b[3mHello (\u200bhttps://google.com)\x1b[m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestItalicsBoldLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold italic"),
-			"\x1b]8;;https://google.com\a\x1b[1;3mHello\x1b]8;;\a\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "bold italic")
+		expected := "\x1b]8;;https://google.com\a\x1b[1;3mHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "bold italic"), "\x1b[1;3mHello (\u200bhttps://google.com)\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "bold italic")
+		expected := "\x1b[1;3mHello (\u200bhttps://google.com)\x1b[m"
+		assert.Equal(t, input, expected)
 	}
 }
 
 func TestColorItalicsBoldLink(t *testing.T) {
 	if termlink.SupportsHyperlinks() {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red bold italic"),
-			"\x1b]8;;https://google.com\a\x1b[31;1;3mHello\x1b]8;;\a\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "red bold italic")
+		expected := "\x1b]8;;https://google.com\a\x1b[31;1;3mHello\x1b]8;;\a\x1b[m"
+		assert.Equal(t, input, expected)
 	} else {
-		assert.Equal(t, termlink.ColorLink("Hello", "https://google.com", "red bold italic"), "\x1b[31;1;3mHello (\u200bhttps://google.com)\x1b[m")
+		input := termlink.ColorLink("Hello", "https://google.com", "red bold italic")
+		expected := "\x1b[31;1;3mHello (\u200bhttps://google.com)\x1b[m"
+		assert.Equal(t, input, expected)
 	}
 }


### PR DESCRIPTION
## Description

Closes #1 

This pull requests adds basic unit tests for this package

Tests currently included are:

`TestBasicLink`
`TestColorLink`
`TestColorsPackageLink`
`TestBoldLink`
`TestItalicsLink`
`TestItalicsBoldLink`
`TestColorItalicsBoldLink`

More tests will be added soon

There's a main handler function called `testAll` that tests both types of test in one go, without the need to check for `SupportsHyperlink()` everytime using logic statements. A basic structure of a test is as follows:
```go
func TestBasicLink(t *testing.T) {
	input := termlink.Link("Hello", "https://google.com")
	expectedHyperlink := "\x1b]8;;https://google.com\aHello\x1b]8;;\a\x1b[m"
	expectedNoHyperlink := "Hello (\u200Bhttps://google.com)\u001b[m"

	testAll(input, expectedHyperlink, expectedNoHyperlink)(t)
}
```

Run the tests using `go test -v`. Please ensure the tests are run both in hyperlink and non-hyperlink supported terminals. I had used Zsh on WSL with Windows Terminal for the hyperlink tests and Zsh on WSL with VSCode for the non-hyperlink tests.
