### PR TITLE
feat: add `shouldForce` parameter to functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD010 MD033 -->
+<!-- markdownlint-disable MD010 MD033 MD001 -->
 
 # termlink
 
@@ -67,8 +67,8 @@ func main() {
 ```
 
 > #### Note: For unsupported terminals, the link will be printed in parentheses after the text (see below image)
+>
 > ![image](https://user-images.githubusercontent.com/38729705/163216009-abb81d39-aff0-4fb5-8c5f-da36e241b395.png)
-
 
 ---
 
@@ -80,12 +80,13 @@ More examples can be found in the [`examples/`](examples/) directory.
 
 ## 🔮 Features
 
-- **`termlink.Link(text, url)`**
+- **`termlink.Link(text, url, [shouldForce])`**
 
   - Creates a regular, clickable link in the terminal
   - For unsupported terminals, the link will be printed in parentheses after the text: `Example Link (https://example.com)`.
+  - The `shouldForce` is an optional boolean parameter which allows you to force the above unsupported terminal hyperlinks format `text (url)` to be printed, even in supported terminals
 
-- **`termlink.ColorLink(text, url, color)`**
+- **`termlink.ColorLink(text, url, color, [shouldForce])`**
 
   - Creates a clickable link in the terminal with custom color formatting
   - Examples of color options include:
@@ -93,6 +94,7 @@ More examples can be found in the [`examples/`](examples/) directory.
     - Background only: `bgGreen`, `bgRed`, `bgBlue`, etc.
     - Foreground and background: `green bgRed`, `bgBlue red`, etc.
     - With formatting: `green bold`, `red bgGreen italic`, `italic blue bgGreen`, etc.
+  - The `shouldForce` is an optional boolean parameter which allows you to force the above unsupported terminal hyperlinks format `text (url)` to be printed, even in supported terminals
 
 - **`termlink.SupportsHyperlinks()`**:
 

--- a/termlink.go
+++ b/termlink.go
@@ -155,12 +155,12 @@ func Link(text string, url string, shouldForce ...bool) string {
 	}
 
 	if shouldForceDefault {
-		return text + " (\u200B" + url + ")" + parseColor("reset")
+		return text + " (" + url + ")" + parseColor("reset")
 	} else {
 		if supportsHyperlinks() {
 			return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07" + parseColor("reset")
 		}
-		return text + " (\u200B" + url + ")" + parseColor("reset")
+		return text + " (" + url + ")" + parseColor("reset")
 	}
 }
 
@@ -191,12 +191,12 @@ func ColorLink(text string, url string, color string, shouldForce ...bool) strin
 	}
 
 	if shouldForceDefault {
-		return textColor + text + " (\u200B" + url + ")" + parseColor("reset")
+		return textColor + text + " (" + url + ")" + parseColor("reset")
 	} else {
 		if supportsHyperlinks() {
 			return "\x1b]8;;" + url + "\x07" + textColor + text + "\x1b]8;;\x07" + parseColor("reset")
 		}
-		return textColor + text + " (\u200B" + url + ")" + parseColor("reset")
+		return textColor + text + " (" + url + ")" + parseColor("reset")
 	}
 }
 

--- a/termlink.go
+++ b/termlink.go
@@ -139,10 +139,12 @@ func supportsColor() bool {
 
 // Function Link creates a clickable link in the terminal's stdout.
 //
-// The function takes two parameters: text and url.
+// The function takes two required parameters: text and url
+// and one optional parameter: shouldForce
 //
 // The text parameter is the text to be displayed.
 // The url parameter is the URL to be opened when the link is clicked.
+// The shouldForce parameter indicates whether to force the non-hyperlink supported behavior (i.e., text (url))
 //
 // The function returns the clickable link.
 func Link(text string, url string, shouldForce ...bool) string {
@@ -164,11 +166,13 @@ func Link(text string, url string, shouldForce ...bool) string {
 
 // Function LinkColor creates a colored clickable link in the terminal's stdout.
 //
-// The function takes three parameters: text, url and color.
+// The function takes three required parameters: text, url and color
+// and one optional parameter: shouldForce
 //
 // The text parameter is the text to be displayed.
 // The url parameter is the URL to be opened when the link is clicked.
 // The color parameter is the color of the link.
+// The shouldForce parameter indicates whether to force the non-hyperlink supported behavior (i.e., text (url))
 //
 // The function returns the clickable link.
 func ColorLink(text string, url string, color string, shouldForce ...bool) string {

--- a/termlink.go
+++ b/termlink.go
@@ -145,10 +145,19 @@ func supportsColor() bool {
 // The url parameter is the URL to be opened when the link is clicked.
 //
 // The function returns the clickable link.
-func Link(text string, url string) string {
-	if supportsHyperlinks() {
-		return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07" + parseColor("reset")
+func Link(text string, url string, shouldForce ...bool) string {
+	shouldForceDefault := false
+
+	if len(shouldForce) > 0 {
+		shouldForceDefault = shouldForce[0]
+	}
+
+	if shouldForceDefault {
+		return text + " (\u200B" + url + ")" + parseColor("reset")
 	} else {
+		if supportsHyperlinks() {
+			return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07" + parseColor("reset")
+		}
 		return text + " (\u200B" + url + ")" + parseColor("reset")
 	}
 }
@@ -162,7 +171,7 @@ func Link(text string, url string) string {
 // The color parameter is the color of the link.
 //
 // The function returns the clickable link.
-func ColorLink(text string, url string, color string) string {
+func ColorLink(text string, url string, color string, shouldForce ...bool) string {
 	var textColor string
 
 	if supportsColor() {
@@ -170,9 +179,19 @@ func ColorLink(text string, url string, color string) string {
 	} else {
 		textColor = ""
 	}
-	if supportsHyperlinks() {
-		return "\x1b]8;;" + url + "\x07" + textColor + text + "\x1b]8;;\x07" + parseColor("reset")
+
+	shouldForceDefault := false
+
+	if len(shouldForce) > 0 {
+		shouldForceDefault = shouldForce[0]
+	}
+
+	if shouldForceDefault {
+		return textColor + text + " (\u200B" + url + ")" + parseColor("reset")
 	} else {
+		if supportsHyperlinks() {
+			return "\x1b]8;;" + url + "\x07" + textColor + text + "\x1b]8;;\x07" + parseColor("reset")
+		}
 		return textColor + text + " (\u200B" + url + ")" + parseColor("reset")
 	}
 }


### PR DESCRIPTION
### Description

Closes #4 and #5 

This pull request includes the following changes:
- Removes the unwanted `u200B`, which caused an extra space to occur
- Adds an optional parameter called `shouldForce` to the `Link` and `ColorLink` functions, which allows you to programmatically force the non-linked behavior
- Update docs (godoc and readme)