### PR TITLE
support JetBrains IDEs terminal

### DIFF
--- a/termlink.go
+++ b/termlink.go
@@ -134,6 +134,11 @@ func supportsHyperlinks() bool {
 		return true
 	}
 
+	// Terminals in JetBrains IDEs
+	if matchesEnv("TERMINAL_EMULATOR", []string{"JetBrains-JediTerm"}) {
+		return true
+	}
+
 	// Match standalone environment variables
 	// ie, those which do not require any special handling
 	// or version checking


### PR DESCRIPTION
Support JetBrains IDEs

P.S.
tmux also uses this method ([forum link](https://youtrack.jetbrains.com/issue/IJPL-114188/Add-environment-variable-to-terminal-detect-if-running-in-IntelliJ-IDES))