### PR TITLE
feat: add support for windows terminal ssh session

### DIFF
--- a/termlink.go
+++ b/termlink.go
@@ -125,7 +125,7 @@ func supportsHyperlinks() bool {
 	}
 
 	// Terminals which have a TERM variable set
-	if matchesEnv("TERM", []string{"xterm-kitty", "alacritty", "alacritty-direct"}) {
+	if matchesEnv("TERM", []string{"xterm-kitty", "xterm-256color", "alacritty", "alacritty-direct"}) {
 		return true
 	}
 


### PR DESCRIPTION
When using the Windows Terminal to establish an SSH session, the session supports hyperlinks, and the TERM environment variable of the session is xterm-256color.

![image](https://github.com/user-attachments/assets/b2bd5cff-5e84-4b94-8b34-6cce9110985e)
