### PR TITLE
Add support for ghostty

### DIFF
--- a/termlink.go
+++ b/termlink.go
@@ -121,11 +121,15 @@ func supportsHyperlinks() bool {
 
 			// Hyper Terminal used to be included in this list, and it even supports hyperlinks
 			// but the hyperlinks are pseudo-hyperlinks and are actually not clickable
+		case "ghostty":
+			// it is unclear when during the private beta that ghostty started supporting hyperlinks,
+			// so we'll start from the public release.
+			return v.major >= 1
 		}
 	}
 
 	// Terminals which have a TERM variable set
-	if matchesEnv("TERM", []string{"xterm-kitty", "xterm-256color", "alacritty", "alacritty-direct"}) {
+	if matchesEnv("TERM", []string{"xterm-kitty", "xterm-256color", "alacritty", "alacritty-direct", "xterm-ghostty"}) {
 		return true
 	}
 


### PR DESCRIPTION
Adds support for detecting [Ghostty](https://ghostty.org/) in `TERM` and `TERM_PROGRAM`/`TERM_PROGRAM_VERSION`.

Closes #12 