### PR TITLE
remove early return in swith on TERM_PROGRAM

### DIFF
--- a/termlink.go
+++ b/termlink.go
@@ -122,8 +122,6 @@ func supportsHyperlinks() bool {
 			// It is unclear when during the private beta that ghostty started supporting hyperlinks,
 			// so we'll start from the public release.
 			return v.major >= 1
-		default:
-			return false
 
 			// Hyper Terminal used to be included in this list, and it even supports hyperlinks
 			// but the hyperlinks are pseudo-hyperlinks and are actually not clickable


### PR DESCRIPTION
This fixes links in terminals that support links and use _tmux_.

The problem is that _tmux_ sets "TERM_PROGRAM", and with this introduction of the early return [here](https://github.com/savioxavier/termlink/commit/a27db487449b95d04bab6ed40bb5e1c6e8894b5f#diff-bc78b0d438db39fb41f83174650a96a1bf11d2467352eb437611d13139f3225bR125-R126) it no longer works when running _tmux_ in a supported terminal (i.e. `TERM=xterm-ghostty`)