### PR TITLE
feat(terms): add support for zed editor built-in terminal

### DIFF
--- a/termlink.go
+++ b/termlink.go
@@ -122,6 +122,9 @@ func supportsHyperlinks() bool {
 			// It is unclear when during the private beta that ghostty started supporting hyperlinks,
 			// so we'll start from the public release.
 			return v.major >= 1
+		case "zed":
+			// Zed uses alacritty since 0.43 release
+			return v.major > 0 || (v.major == 0 && v.minor >= 43)
 
 			// Hyper Terminal used to be included in this list, and it even supports hyperlinks
 			// but the hyperlinks are pseudo-hyperlinks and are actually not clickable


### PR DESCRIPTION
Hi!

I've added support for zed built-in terminal

```bash
$ env | grep -E '(VTE\|HYPERLINK|TERM|WT|FORCE)'
TERMINFO=...
TERM_PROGRAM_VERSION=0.224.8+stable.169.737ce190372e31ace8c0415146b1f827fb787336
TERMINFO_DIRS=...
ZED_TERM=true
COLORTERM=truecolor
TERM=xterm-256color
TERM_PROGRAM=zed
```

Zed editor uses `alacritty >= 0.16` since [v0.43.0](https://github.com/zed-industries/zed/compare/v0.42.0...v0.43.0), [PR 1255](https://github.com/zed-industries/zed/pull/1255)
Alacritty [supports](https://github.com/zed-industries/alacritty/blob/a2334ff494a26a38f66685d0f950a9b589ac84a9/CHANGELOG.md?plain=1#L375) OSC8 hyperlinks since `0.11`